### PR TITLE
Fix out of memory error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 
 all:
+	# Setup submodules
+	git submodule update --init
 	# Install dependencies
 	npm install .
 	# Compile seqtk to WASM
+	mkdir -p wasm/
 	emcc seqtk/seqtk.c \
 		-s USE_ZLIB=1 \
 		-s FORCE_FILESYSTEM=1 \
 		-s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' \
 		-s WASM=1 \
+		-s ALLOW_MEMORY_GROWTH=1 \
 		-o wasm/seqtk.js

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "An interactive web tool for quality control of DNA sequencing data",
   "dependencies": {
-    "@robertaboukhalil/aioli": "^0.1.6"
+    "@robertaboukhalil/aioli": "0.1.6"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "An interactive web tool for quality control of DNA sequencing data",
   "dependencies": {
-    "@robertaboukhalil/aioli": "0.1.6"
+    "@robertaboukhalil/aioli": "0.1.7"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "fastq.bio",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An interactive web tool for quality control of DNA sequencing data",
   "dependencies": {
-    "@robertaboukhalil/aioli": "0.1.6"
+    "@robertaboukhalil/aioli": "^0.1.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update flags used during compilation to Wasm to allow for memory growth. Otherwise, sometimes get this error with Nanopore data ([sample data](https://trace.ncbi.nlm.nih.gov/Traces/sra/?run=ERR2704821)):

```
uncaught exception: abort("Cannot enlarge memory arrays.
Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value 16777216,
(2) compile with  -s ALLOW_MEMORY_GROWTH=1  which allows increasing the size at runtime,
or (3) if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0 ").
Build with -s ASSERTIONS=1 for more info.
```